### PR TITLE
Fix errors caused by recent method rename changes in VRCSDK - Worlds 3.1.9 and VRCSDK3 2020.3.2

### DIFF
--- a/Packages/com.varneon.udonexplorer/Editor/UdonListView.cs
+++ b/Packages/com.varneon.udonexplorer/Editor/UdonListView.cs
@@ -387,7 +387,12 @@ namespace Varneon.UdonExplorer
         private void OpenUdonGraph(object userData)
         {
             UdonGraphWindow window = EditorWindow.GetWindow<UdonGraphWindow>("Udon Graph", true, typeof(SceneView));
+
+#if VRCSDK_WORLDS_3_1_9_OR_NEWER // The method for opening an UdonGraphProgramAsset got renamed to 'LoadGraphFromAsset' in 3.1.9
+            window.LoadGraphFromAsset((UdonGraphProgramAsset)userData);
+#else
             window.InitializeGraph((UdonGraphProgramAsset)userData);
+#endif
         }
 
         internal class UdonBehaviourInfo : TreeViewItem

--- a/Packages/com.varneon.udonexplorer/Editor/UdonListView.cs
+++ b/Packages/com.varneon.udonexplorer/Editor/UdonListView.cs
@@ -388,7 +388,7 @@ namespace Varneon.UdonExplorer
         {
             UdonGraphWindow window = EditorWindow.GetWindow<UdonGraphWindow>("Udon Graph", true, typeof(SceneView));
 
-#if VRCSDK_WORLDS_3_1_9_OR_NEWER // The method for opening an UdonGraphProgramAsset got renamed to 'LoadGraphFromAsset' in 3.1.9
+#if VRCSDK_WORLDS_3_1_9_OR_NEWER || VRCSDK3_2020_3_2_OR_NEWER // The method for opening an UdonGraphProgramAsset got renamed to 'LoadGraphFromAsset' in 3.1.9 (2020.3.2)
             window.LoadGraphFromAsset((UdonGraphProgramAsset)userData);
 #else
             window.InitializeGraph((UdonGraphProgramAsset)userData);

--- a/Packages/com.varneon.udonexplorer/Editor/Varneon.UdonExplorer.Editor.asmdef
+++ b/Packages/com.varneon.udonexplorer/Editor/Varneon.UdonExplorer.Editor.asmdef
@@ -16,6 +16,12 @@
         "VRC_SDK_VRCSDK3",
         "UDON"
     ],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.vrchat.worlds",
+            "expression": "3.1.9",
+            "define": "VRCSDK_WORLDS_3_1_9_OR_NEWER"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Packages/com.varneon.udonexplorer/Editor/Varneon.UdonExplorer.Editor.asmdef
+++ b/Packages/com.varneon.udonexplorer/Editor/Varneon.UdonExplorer.Editor.asmdef
@@ -21,6 +21,11 @@
             "name": "com.vrchat.worlds",
             "expression": "3.1.9",
             "define": "VRCSDK_WORLDS_3_1_9_OR_NEWER"
+        },
+        {
+            "name": "com.vrchat.vrcsdk3",
+            "expression": "2020.3.2",
+            "define": "VRCSDK3_2020_3_2_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Packages/com.varneon.udonexplorer/package.json
+++ b/Packages/com.varneon.udonexplorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.udonexplorer",
   "displayName": "UdonExplorer",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "unity": "2019.4",
   "description": "Unity Editor extension for easily exploring all VRCSDK3 UdonBehaviours in your Unity scene.",
   "author": {

--- a/Packages/com.varneon.udonexplorer/package.json
+++ b/Packages/com.varneon.udonexplorer/package.json
@@ -13,5 +13,6 @@
   },
   "legacyFolders": {
     "Assets\\Varneon\\UdonExplorer": ""
-  }
+  },
+  "unityRelease": "29f1"
 }


### PR DESCRIPTION
Fixes #3 

# Current Solution
* Added version defines to the Editor assembly definition to detect the current version of the VRCSDK - Worlds and VRCSDK3: 
![Unity_rQkOFh73wA](https://user-images.githubusercontent.com/26690821/196642610-b00759e4-2443-47b6-a965-236cae8162eb.png)

* Added conditional compilation based on the current version:
![devenv_DYOzpQ5O7c](https://user-images.githubusercontent.com/26690821/196642743-217f71c9-3d2f-49fb-ad0d-60dd444e227e.png)