### PR TITLE
Allow hiding of "Varneon" toolbar menu item on the Unity Editor

### DIFF
--- a/Packages/com.varneon.udonexplorer/Editor/UdonExplorerWindow.cs
+++ b/Packages/com.varneon.udonexplorer/Editor/UdonExplorerWindow.cs
@@ -32,7 +32,11 @@ namespace Varneon.UdonExplorer
             RefreshButtonContent = new GUIContent("Refresh", "Manually refresh the explorer");
         private static GUIStyle RichTextStyle = new GUIStyle();
 
+#if VARNEON_HIDE_TOOLBAR_MENU
+        [MenuItem("Window/Varneon/Udon Explorer")]
+#else
         [MenuItem("Varneon/Udon Explorer")]
+#endif
         public static void Init()
         {
             EditorWindow window = GetWindow<UdonExplorerWindow>("Udon Explorer", true);

--- a/Packages/com.varneon.udonexplorer/package.json
+++ b/Packages/com.varneon.udonexplorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.varneon.udonexplorer",
   "displayName": "UdonExplorer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "unity": "2019.4",
   "description": "Unity Editor extension for easily exploring all VRCSDK3 UdonBehaviours in your Unity scene.",
   "author": {


### PR DESCRIPTION
Closes #5 

You can now add a [Scripting Define Symbol](https://docs.unity3d.com/Manual/CustomScriptingSymbols.html) called `VARNEON_HIDE_TOOLBAR_MENU`, this will move the menu item from `Varneon/Udon Explorer` to `Window/Varneon/Udon Explorer`:

![image](https://user-images.githubusercontent.com/26690821/211986456-f31773fd-e856-437e-be08-8332d590981d.png)